### PR TITLE
refs qorelanguage/qore#563 char values are sent with format = CS_FMT_UNUSED and the ex…

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -18,6 +18,7 @@ implemented:
   - "numeric-numbers": return numeric types as arbitrary-precision number values
   - "timezone": accepts a string argument that can be either a region name (ex: "Europe/Prague") or a UTC offset (ex: "+01:00") to set the server's time zone rules; this is useful if connecting to a database server in a different time zone.  If this option is not set then the server's time zone is assumed to be the same as the client's time zone
 - the default for the number options is now "optimal-numbers", meaning that NUMERIC or DECIMAL values are retrieved as integers if possible, otherwise an arbitrary-precision number type is returned
+- fixed varchar handling with freetds; freetds processes bind arguments differently than Sybase's ctlib and strings were sent with an extra space on the end that was stripped from the string when the value was returned from the DB (bug 563)
 
 
 -------------

--- a/docs/mainpage.dox.tmpl
+++ b/docs/mainpage.dox.tmpl
@@ -155,8 +155,10 @@ DataourcePool dsp("freetds:user/pass@db%host.internal:1433{optimal-numbers}");
     |\c SMALLMONEY|@ref Qore::Type::Float|both|direct conversion
     |\c DATETIME|@ref Qore::Type::Date|both|1/300 second values are converted and rounded to the nearest microsecond
     |\c SMALLDATETIME|@ref Qore::Type::Date|both|direct conversion
-    |\c DATE|@ref Qore::Type::Date|both|direct conversion
-    |\c TIME|@ref Qore::Type::Date|both|Date portion is set to '1970-01-01'; 1/300 second values are converted and rounded to the nearest microsecond
+    |\c DATE|@ref Qore::Type::Date|sybase|direct conversion
+    |\c DATE|@ref Qore::Type::Date|freetds|currently returned as a string with MS SQL Server DBs
+    |\c TIME|@ref Qore::Type::Date|sybase|Date portion is set to '1970-01-01'; 1/300 second values are converted and rounded to the nearest microsecond
+    |\c TIME|@ref Qore::Type::Date|freetds|currently returned as a string with MS SQL Server DBs
     |\c CHAR|@ref Qore::Type::String|both|trailing blanks are removed
     |\c VARCHAR|@ref Qore::Type::String|both|direct conversion
     |\c UNICHAR|@ref Qore::Type::String|sybase|trailing blanks are removed
@@ -214,6 +216,7 @@ exec get_values :string output, :int output");
       - \c "numeric-numbers": return numeric types as arbitrary-precision number values
       - \c "timezone": accepts a string argument that can be either a region name (ex: \c "Europe/Prague") or a UTC offset (ex: \c "+01:00") to set the server's time zone rules; this is useful if connecting to a database server in a different time zone.  If this option is not set then the server's time zone is assumed to be the same as the client's time zone
     - the default for the number options is now \c  "optimal-numbers", meaning that \c NUMERIC or \c DECIMAL values are retrieved as integers if possible, otherwise an arbitrary-precision number type is returned
+    - fixed \c varchar handling with freetds; freetds processes bind arguments differently than Sybase's ctlib and strings were sent with an extra space on the end that was stripped from the string when the value was returned from the DB (<a href="https://github.com/qorelanguage/qore/issues/563">bug 563</a>)
 
     @subsection sybase_103 sybase Driver Version 1.0.3
 

--- a/test/sybase-types.qtest
+++ b/test/sybase-types.qtest
@@ -1,15 +1,17 @@
 #!/usr/bin/env qore
 
-%requires sybase
 %new-style
+%require-types
+%strict-args
 
 %requires QUnit
 
-
 our Datasource ds;
 
-string tdata = "create table ssmrt_table_%s (%s)";
-string tdrop = "drop table ssmrt_table_%s";
+
+
+string tdata = "create table ssyb_table_%s (%s)";
+string tdrop = "drop table ssyb_table_%s";
 
 hash cols = (
 "varchar_f": "varchar_f varchar(40) not null",
@@ -35,7 +37,7 @@ hash cols = (
 "image_f": "image_f image not null",
 );
 
-hash args = (
+const Args = (
     "varchar_f"       : "varchar",
     "char_f"          : "char",
     "unichar_f"       : "unichar",
@@ -61,7 +63,14 @@ hash args = (
     "image_f"         : <cafebead>,
     );
 
-sub create_smrt_tables() {
+const Expect = (
+    "decimal_f": 500.1231n,
+    "real_f": False,
+    "date_f": "2007-05-01",
+    "time_f": "10:30:01.0000000",
+    );
+
+sub create_syb_tables() {
     foreach string k in (cols.keys()) {
         try {
             string command = sprintf(tdata, k, cols{k});
@@ -71,7 +80,7 @@ sub create_smrt_tables() {
     ds.commit();
 }
 
-sub drop_smrt_tables() {
+sub drop_syb_tables() {
     foreach string k in (cols.keys()) {
         string command = sprintf(tdrop, k);
         try {
@@ -81,36 +90,44 @@ sub drop_smrt_tables() {
     ds.commit();
 }
 
-sub test_insert(string col) {
+any sub test_insert(string col, any val) {
     string itempl = "insert into %s values (%v)";
-    string ttempl = "ssmrt_table_%s";
+    string ttempl = "ssyb_table_%s";
 
     string t = sprintf(ttempl, col);
     string query = sprintf(itempl, t);
 
-    ds.vexec(query, args{col});
-    ds.commit();
-    return True;
+    on_exit ds.commit();
+    ds.vexec(query, Args{col});
+    any v = ds.selectRow("select %s from %s", col, t){col};
+    return val != False ? v : val;
 }
 
-
 public class QUnitTest inherits QUnit::Test {
-    constructor() {
-        string addr = getEnv("DB_SYBASE", "sybase:test/test@sybase");
+    public {
+	const Blacklist = (
+	    "freetds": ("unitext_f",),
+	    );
+    }
+
+    constructor() : Test("sybase", "1.0") {
+        string addr = getEnv("DB_SYBASE", "freetds:test/test@mssql");
         ds = new Datasource(addr);
-        create_smrt_tables();
- 
-        testFunctions = ();
-    
-        foreach string k in (cols.keys()) {
-            testFunctions += ("func" : \testInsert(),
-                "name": sprintf("type insert %s", k), "args": list(k));
-        }
+        create_syb_tables();
+
+	addTestCase("simple", \test());
+    }
+
+    test() {
+	hash h = cols;
+	h -= Blacklist{ds.getDriverName()};
+	map testInsert($1), h.keyIterator();
     }
 
     testInsert(string k) {
         string detail = sprintf("type: %s", k);
-        testAssertion(\test_insert(), (k));
+	any val = Expect{k} ?? Args{k};
+	assertEq(val, test_insert(k, val), detail);
     }
 
     basicTest() {
@@ -120,7 +137,7 @@ public class QUnitTest inherits QUnit::Test {
     }
 
     destructor() {
-        drop_smrt_tables();
+        drop_syb_tables();
     }
 }
 


### PR DESCRIPTION
…act byte length of the string to avoid having varchar values stored with an extra space at the end of the string
