### PR TITLE
Revert debug to be enabled by default to be consistent with other modules and to be compatible with Qrb.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -709,7 +709,7 @@ AC_ARG_ENABLE([debug],
        yes|no) ;;
        *)      AC_MSG_ERROR(bad value ${enable_debug} for --enable-debug) ;;
       esac],
-     [enable_debug=no])
+     [enable_debug=yes])
 
 if test "${enable_debug}" = yes; then
    AC_DEFINE(DEBUG, 1, Define if debugging support should be included)


### PR DESCRIPTION
We should change this in all modules to be disabled by default though, IMHO. Open for discussion.
